### PR TITLE
Fixing the seeding problem

### DIFF
--- a/infilling/krig_DCENT.py
+++ b/infilling/krig_DCENT.py
@@ -501,7 +501,7 @@ def main():  # noqa: C901, D103
                 print(f"Skipping {month = }")
                 continue
 
-            np.random.seed(_set_seed(member, month))
+            _set_seed(member, month)
             interp_covariance = interp_covariances[month - 1]
             print(f"{interp_covariance = }")
             logging.info("Loaded ellipse interpolation covariance")


### PR DESCRIPTION
The call:

`np.random.seed(_set_seed(member, month))`

appears to be incorrect. Random numbers are not replicable if seeded this way.

The correct code should be:

`_set_seed(member, month)`

The actual `_set_seed` is working as intended.